### PR TITLE
Support protobuf `extend` keyword when in `kImportEs6` mode

### DIFF
--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3685,7 +3685,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // printer->Print(prefix);
   // const std::string expr = JsExpression(desc->full_name());
   // printer->Print("\n\n$expr$\n\n", expr);
-  const std::string expr = GetMessagePath(options, desc);
+  const std::string expr = GetPrefix(options, field->file(), desc->containing_type());
   //printer->Print(expr);
   printer->Print(
       "// $expr$\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -2071,7 +2071,7 @@ void Generator::GenerateClassEs6(const GeneratorOptions& options,
 
   printer->Indent();
 
-  GenerateClassConstructor(options, printer, desc);
+  GenerateClassConstructorAndDeclareExtensionFieldInfo(options, printer, desc);
 
   GenerateClassFieldInfo(options, printer, desc);
 

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3672,9 +3672,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
            : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
-  GenerateClass(options, type_names, printer, field);
-  GenerateClassRegistration(options, type_names, printer, field);
-  GenerateClassFields(options, type_names, printer, field);
+  GenerateClass(options, type_names, printer, field->message_type());
+  GenerateClassRegistration(options, type_names, printer, field->message_type());
+  GenerateClassFields(options, type_names, printer, field->message_type());
   printer->Print(
       "\n"
       //"class ExtendedClass extends $class$ {}\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3673,8 +3673,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
-  const Descriptor* desc = field->file()->message_type(0);
-
+  const Descriptor* desc = field->file()->message_type();
   GenerateClass(options, type_names, printer, desc);
   GenerateClassRegistration(options, type_names, printer, desc);
   GenerateClassFields(options, type_names, printer, desc);

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3724,7 +3724,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       "MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       //"$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    foo,\n"
-      "    $class$.$name$,\n"
+      //"    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"
       "    $binaryMessageSerializeFn$,\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3669,6 +3669,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
   std::string extension_scope = TypeNames::JsName(field->file()->extension(0)->full_name());
+  if (field->file()->is_extension()) {
+    extension_scope = "foobarbaz\n";
+  }
   //std::string extension_scope = type_names.JsExpression(field->extension_scope()->full_name());
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = type_names.SubmessageTypeRef(field);
+  std::string extension_scope = type_names.JsExpression(field);
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  
       //ImportAliases(type_names, *file->dependency(i))

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3733,7 +3733,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       // "    MethodOptions.extensionBinary = [];\n"
       // "}\n"
       //"MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
-      "$extendName$.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      "$extendName$.extensionsBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3676,7 +3676,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   //This may not even be what I want for extension
   const Descriptor* desc = field->file()->message_type(0);
-  const std::string alias = type_names->Es6TypeName();
+  const std::string alias = TypeNames::Es6TypeName();
   printer->Print("\n\n", alias, "\n\n");
   // how to generate NEW class, not in options?
   // GenerateClassEs6(options, type_names, printer, desc);

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = TypeNames::JsName(field->extension_scope()->name());
+  std::string extension_scope = TypeNames::JsName(field->extension_scope());
   //std::string extension_scope = type_names.JsExpression(field->extension_scope()->full_name());
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3689,8 +3689,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
       ""
-      "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
-      //"var foo = new jspb.ExtensionFieldInfo(\n",
+      //"$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
+      "var foo = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
       "class", extension_scope, "extensionType", 
       JSFieldTypeAnnotation(options, field,
@@ -3718,12 +3718,12 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   printer->Print(
       "\n"
-      // "if(!MethodOptions.extensionBinary) {\n"
-      // "    MethodOptions.extensionBinary = [];\n"
-      // "}\n"
-      //"MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
-      "$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
-      //"    foo,\n"
+      "if(!MethodOptions.extensionBinary) {\n"
+      "    MethodOptions.extensionBinary = [];\n"
+      "}\n"
+      "MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      //"$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      "    foo,\n"
       "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"
@@ -3749,11 +3749,11 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   printer->Print(
       "// This registers the extension field with the extended class, so that\n"
       "// toObject() will function correctly.\n"
-      // "if(!MethodOptions.extensions) {\n"
-      // "    MethodOptions.extensions = [];\n"
-      // "}\n"
-      "$extendName$[$index$] = $class$.$name$;\n"
-      //"MethodOptions.extensions[$index$] = foo;\n" //$class$.$name$;\n"
+      "if(!MethodOptions.extensions) {\n"
+      "    MethodOptions.extensions = [];\n"
+      "}\n"
+      //"$extendName$[$index$] = $class$.$name$;\n"
+      "MethodOptions.extensions[$index$] = foo;\n" //$class$.$name$;\n"
       "\n",
       "extendName",
       JSExtensionsObjectName(options, field->file(), field->containing_type()),

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3683,7 +3683,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   
   printer->Print(
       "\n"
-      //"class ExtendedClass extends $class$ {}\n"
+      "class ExtendedClass extends $class$ {}\n //$nameInComment$"
       //"class ExtendedMethodOptions extends proto.google.protobuf.MethodOptions {}\n"
       "/**\n"
       " * A tuple of {field number, class constructor} for the extension\n"
@@ -3692,8 +3692,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " */\n"
       //"ExtendedClass.$name$ = new jspb.ExtensionFieldInfo(\n",
       "$classname$ = new jspb.ExtensionFieldInfo(\n",
-      "nameInComment", extension_object_name, "name", extension_object_name,
-      "class", extension_scope, "extensionType", "classname", desc->name(),
+      "nameInComment", extension_object_name, "classname", desc->name(), //"name", extension_object_name,
+      "class", extension_scope, "extensionType", 
       JSFieldTypeAnnotation(options, field,
                             /* is_setter_argument = */ false,
                             /* force_present = */ true,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -2071,7 +2071,7 @@ void Generator::GenerateClassEs6(const GeneratorOptions& options,
 
   printer->Indent();
 
-  GenerateClassConstructorAndDeclareExtensionFieldInfo(options, printer, desc);
+  GenerateClassConstructor(options, printer, desc);
 
   GenerateClassFieldInfo(options, printer, desc);
 

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -2030,7 +2030,6 @@ void Generator::GenerateClass(const GeneratorOptions& options,
 
     if (options.import_style != GeneratorOptions::kImportClosure) {
       for (int i = 0; i < desc->extension_count(); i++) {
-        printer->Print("//about to generate extension\n");
         GenerateExtension(options, type_names, printer, desc->extension(i));
       }
     }
@@ -3668,12 +3667,12 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   std::string extension_scope_name =
-    (field->containing_type()
-      ? TypeNames::JsName(field->containing_type()->name())
-      : GetNamespace(options, field->file()));
+      (field->containing_type()
+          ? TypeNames::JsName(field->containing_type()->name())
+          : GetNamespace(options, field->file()));
 
-  const std::string extend_name = extension_scope_name + ".extensions";
-  const std::string extension_object_name = JSObjectFieldName(options, field);
+  std::string extend_name = extension_scope_name + ".extensions";
+  std::string extension_object_name = JSObjectFieldName(options, field);
 
   printer->Print(
       "\n"
@@ -4443,7 +4442,6 @@ bool Generator::GenerateAll(const std::vector<const FileDescriptor*>& files,
         FindProvidesForFields(options, &printer, fields, &provided);
         GenerateProvides(options, &printer, &provided);
         GenerateTestOnly(options, &printer);
-        //TODO:DM -  or imports for es6?
         GenerateRequiresForExtensions(options, &printer, fields, &provided);
 
         for (int j = 0; j < files[i]->extension_count(); j++) {

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3684,7 +3684,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // const std::string prefix = GetMessagePathPrefix(options, desc);
   // printer->Print(prefix);
   const std::string expr = type_names.JsExpression(desc->full_name());
-  printer->Print("\n\n" + expr + "\n\n");
+  printer->Print("\n\n$expr$\n\n", expr);
   printer->Print(
       "\n"
       "/**\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3683,8 +3683,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   
   // const std::string prefix = GetMessagePathPrefix(options, desc);
   // printer->Print(prefix);
-  const std::string expr = JsExpression(desc->full_name());
-  printer->Print("\n\n$expr$\n\n", expr);
+  // const std::string expr = JsExpression(desc->full_name());
+  // printer->Print("\n\n$expr$\n\n", expr);
   printer->Print(
       "\n"
       "/**\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3667,15 +3667,6 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   const TypeNames& type_names,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
-  //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  //std::string extension_scope = TypeNames::JsName(field->containing_type()->name());
-  // if (field->is_extension()) {
-  //   extension_scope = "foobarbaz\n";
-  // }
-  //std::string extension_scope = type_names.JsExpression(field->extension_scope()->full_name());
-  //std::string extension_scope = type_names.JsExpression(field->message_type());
-  //std::string extension_scope = type_names.JsExpression(field->full_name());  
-      //ImportAliases(type_names, *file->dependency(i))
   std::string extension_scope_name =
     (field->containing_type()
       ? TypeNames::JsName(field->containing_type()->name())
@@ -3684,26 +3675,16 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   const std::string extend_name = extension_scope_name + ".extensions";
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
-  //const std::string classSymbol = options.WantEs6() ? field->extension_scope()->name() : GetMessagePath(options, field->extension_scope());
-  //This may not even be what I want for extension
-  // const Descriptor* desc = field->file()->message_type(0);
-  // const std::string alias = TypeNames::Es6TypeName();
-  // printer->Print("\n\n", alias, "\n\n");
-  // how to generate NEW class, not in options?
-  // GenerateClassEs6(options, type_names, printer, desc);
-
   printer->Print(
       "\n"
       "/**\n"
       " * A tuple of {field number, class constructor} for the extension\n"
-      " * field named `$nameInComment$`.\n"
+      " * field named `$name$`.\n"
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
       ""
       "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
-      //"var foo = new jspb.ExtensionFieldInfo(\n",
-      "nameInComment", extension_object_name, "name", extension_object_name,
-      "class", extension_scope, "extensionType", 
+      "class", extension_scope_name, "name", extension_object_name, "extensionType", 
       JSFieldTypeAnnotation(options, field,
                             /* is_setter_argument = */ false,
                             /* force_present = */ true,
@@ -3729,22 +3710,20 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   printer->Print(
       "\n"
-      // "if(!MethodOptions.extensionBinary) {\n"
-      // "    MethodOptions.extensionBinary = [];\n"
-      // "}\n"
+      "if(!$extendName$Binary) {\n"
+      "    $extendName$Binary = [];\n"
+      "}\n"
       "$extendName$.Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"
       "    $binaryMessageSerializeFn$,\n"
       "    $binaryMessageDeserializeFn$,\n",
-      "extendName",
-      extension_scope + ".extensions",
-      //JSExtensionsObjectName(options, field->file(), field->containing_type()),
-      "index", StrCat(field->number()), "class", extension_scope, "name",
-      extension_object_name, "binaryReaderFn",
-      JSBinaryReaderMethodName(options, field), "binaryWriterFn",
-      JSBinaryWriterMethodName(options, field), "binaryMessageSerializeFn",
+      "extendName", extend_name, "index", StrCat(field->number()),
+      "class", extension_scope_name, "name", extension_object_name,
+      "binaryReaderFn", JSBinaryReaderMethodName(options, field),
+      "binaryWriterFn", JSBinaryWriterMethodName(options, field),
+      "binaryMessageSerializeFn",
       (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE)
           ? (type_names.SubmessageTypeRef(field) + ".serializeBinaryToWriter")
           : "undefined",
@@ -3759,17 +3738,13 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   printer->Print(
       "// This registers the extension field with the extended class, so that\n"
       "// toObject() will function correctly.\n"
-      // "if(!MethodOptions.extensions) {\n"
-      // "    MethodOptions.extensions = [];\n"
-      // "}\n"
-      "$extendName$.extensions[$index$] = $class$.$name$;\n"
-      //"MethodOptions.extensions[$index$] = $class$.$name$;\n"
+      "if(!$extendName$) {\n"
+      "    $extendName$ = [];\n"
+      "}\n"
+      "$extendName$[$index$] = $class$.$name$;\n"
       "\n",
-      "extendName",
-      extension_scope,
-      //JSExtensionsObjectName(options, field->file(), field->containing_type()),
-      "index", StrCat(field->number()), "class", extension_scope, "name",
-      extension_object_name);
+      "extendName", extend_name, "index", StrCat(field->number()),
+      "class", extension_scope_name, "name", extension_object_name);
 }
 
 bool GeneratorOptions::ParseFromOptions(

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3678,7 +3678,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // how to generate NEW class, not in options?
   // GenerateClassEs6(options, type_names, printer, desc);
   printer->Print("\n\n\n\n");
-  GenerateClassRegistration(options, type_names, printer, desc);
+  //GenerateClassRegistration(options, type_names, printer, desc);
   printer->Print("\n\n\n\n");
   
   printer->Print(

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3683,7 +3683,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   
   // const std::string prefix = GetMessagePathPrefix(options, desc);
   // printer->Print(prefix);
-  const std::string expr = TypeNames::JsExpression(desc->full_name()) 
+  const std::string expr = type_names.JsExpression(desc->full_name()) 
   printer->Print("\n\n" + alias + "\n\n");
   printer->Print(
       "\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3667,7 +3667,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   const TypeNames& type_names,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
-  std::string extension_scope = GetNamespace(options, field->file());
+  std::string extension_scope = TypeNames::Es6TypeNames(options, field->file());//GetNamespace(options, field->file());
       // (field->extension_scope()
       //      ? field->extension_scope()->name()
       //      //? GetMessagePath(options, field->extension_scope())
@@ -4459,6 +4459,7 @@ bool Generator::GenerateAll(const std::vector<const FileDescriptor*>& files,
         FindProvidesForFields(options, &printer, fields, &provided);
         GenerateProvides(options, &printer, &provided);
         GenerateTestOnly(options, &printer);
+        //TODO:DM -  or imports for es6?
         GenerateRequiresForExtensions(options, &printer, fields, &provided);
 
         for (int j = 0; j < files[i]->extension_count(); j++) {

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3675,7 +3675,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
-  const std::string classSymbol = options.WantEs6() ? field->extension_scope()->name() : GetMessagePath(options, field->extension_scope());
+  //const std::string classSymbol = options.WantEs6() ? field->extension_scope()->name() : GetMessagePath(options, field->extension_scope());
   //This may not even be what I want for extension
   // const Descriptor* desc = field->file()->message_type(0);
   // const std::string alias = TypeNames::Es6TypeName();

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3669,7 +3669,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
   //std::string extension_scope = TypeNames::JsName(field->full_name());
-  std::string extension_scope = type_names.JsExpression(field->message_type(0));  
+  std::string extension_scope = type_names.JsExpression(field->message_type());  
       //ImportAliases(type_names, *file->dependency(i))
       // (field->extension_scope()
       //      ? field->extension_scope()->name()

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3675,12 +3675,14 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   const Descriptor* desc = field->file()->message_type(0);
   // GenerateClass(options, type_names, printer, desc);
+  printer->Print("\n\n\n\n");
   GenerateClassRegistration(options, type_names, printer, desc);
+  printer->Print("\n\n\n\n");
   //GenerateClassFields(options, type_names, printer, desc);
   printer->Print(
       "\n"
       //"class ExtendedClass extends $class$ {}\n"
-      "class ExtendedMethodOptions extends proto.google.protobuf.MethodOptions {}\n"
+      //"class ExtendedMethodOptions extends proto.google.protobuf.MethodOptions {}\n"
       "/**\n"
       " * A tuple of {field number, class constructor} for the extension\n"
       " * field named `$nameInComment$`.\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3688,7 +3688,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * field named `$nameInComment$`.\n"
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
-      "ExtendedClass.$name$ = new jspb.ExtensionFieldInfo(\n",
+      //"ExtendedClass.$name$ = new jspb.ExtensionFieldInfo(\n",
+      "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
       "class", extension_scope, "extensionType",
       JSFieldTypeAnnotation(options, field,
@@ -3716,8 +3717,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   printer->Print(
       "\n"
-      "ExtendedMethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
-      //"$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      //"ExtendedMethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      "$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3667,8 +3667,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   const TypeNames& type_names,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
-  std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-      
+  //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
+  std::string extension_scope = TypeNames::JsName(field->full_name());    
       //ImportAliases(type_names, *file->dependency(i))
       // (field->extension_scope()
       //      ? field->extension_scope()->name()

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3763,7 +3763,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       // "if(!MethodOptions.extensions) {\n"
       // "    MethodOptions.extensions = [];\n"
       // "}\n"
-      "$extendName$[$index$] = $class$.$name$;\n"
+      "$extendName$.extensions[$index$] = $class$.$name$;\n"
       //"MethodOptions.extensions[$index$] = $class$.$name$;\n"
       "\n",
       "extendName",

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3683,7 +3683,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   
   // const std::string prefix = GetMessagePathPrefix(options, desc);
   // printer->Print(prefix);
-  const expr = std::string TypeNames::JsExpression(desc) 
+  const std::string expr = TypeNames::JsExpression(desc) 
   printer->Print("\n\n" + alias + "\n\n");
   printer->Print(
       "\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3683,7 +3683,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   
   // const std::string prefix = GetMessagePathPrefix(options, desc);
   // printer->Print(prefix);
-  const std::string expr = type_names.JsExpression(desc->full_name());
+  const std::string expr = type_names->JsExpression(desc->full_name());
   printer->Print("\n\n$expr$\n\n", expr);
   printer->Print(
       "\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3748,6 +3748,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   printer->Print(
       "// This registers the extension field with the extended class, so that\n"
       "// toObject() will function correctly.\n"
+      "if(!MethodOptions.extensions) {\n"
+      "    MethodOptions.extensions = [];\n"
+      "}\n"
       //"$extendName$[$index$] = $class$.$name$;\n"
       "MethodOptions.extensions[$index$] = foo;\n" //$class$.$name$;\n"
       "\n",

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3676,7 +3676,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   const Descriptor* desc = field->file()->message_type(0);
   // GenerateClass(options, type_names, printer, desc);
   //GenerateClassRegistration(options, type_names, printer, desc);
-  GenerateClassFields(options, type_names, printer, desc);
+  //GenerateClassFields(options, type_names, printer, desc);
   printer->Print(
       "\n"
       //"class ExtendedClass extends $class$ {}\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3718,6 +3718,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   printer->Print(
       "\n"
+      "if(!MethodOptions.extensionBinary) {\n"
+      "    MethodOptions.extensionBinary = [];\n"
+      "}\n"
       "MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       //"$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    foo,\n"//"    $class$.$name$,\n"
@@ -3746,7 +3749,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       "// This registers the extension field with the extended class, so that\n"
       "// toObject() will function correctly.\n"
       //"$extendName$[$index$] = $class$.$name$;\n"
-      "ExtendedMethodOptions.extensions[$index$] = foo;\n" //$class$.$name$;\n"
+      "MethodOptions.extensions[$index$] = foo;\n" //$class$.$name$;\n"
       "\n",
       "extendName",
       JSExtensionsObjectName(options, field->file(), field->containing_type()),

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3713,7 +3713,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       "if(!$extendName$Binary) {\n"
       "    $extendName$Binary = [];\n"
       "}\n"
-      "$extendName$.Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      "$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3675,7 +3675,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   const Descriptor* desc = field->file()->message_type(0);
   // GenerateClass(options, type_names, printer, desc);
-  //GenerateClassRegistration(options, type_names, printer, desc);
+  GenerateClassRegistration(options, type_names, printer, desc);
   //GenerateClassFields(options, type_names, printer, desc);
   printer->Print(
       "\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = TypeNames::JsName(field->containing_type()->full_name());
+  //std::string extension_scope = TypeNames::JsName(field->containing_type()->name());
   // if (field->is_extension()) {
   //   extension_scope = "foobarbaz\n";
   // }
@@ -3676,10 +3676,11 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  
       //ImportAliases(type_names, *file->dependency(i))
-      // (field->extension_scope()
-      //      ? field->extension_scope()->name()
+  std::string extension_scope = \
+    (field->extension_scope()
+      ? TypeNames::JsName(field->containing_type()->name()) //field->extension_scope()->name()
       //      //? GetMessagePath(options, field->extension_scope())
-      //      : GetNamespace(options, field->file()));
+      : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
@@ -3728,18 +3729,18 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   printer->Print(
       "\n"
-      "if(!MethodOptions.extensionBinary) {\n"
-      "    MethodOptions.extensionBinary = [];\n"
-      "}\n"
-      "MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
-      //"$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
-      "    foo,\n"
-      //"    $class$.$name$,\n"
+      // "if(!MethodOptions.extensionBinary) {\n"
+      // "    MethodOptions.extensionBinary = [];\n"
+      // "}\n"
+      //"MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      "$extendName$.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"
       "    $binaryMessageSerializeFn$,\n"
       "    $binaryMessageDeserializeFn$,\n",
       "extendName",
+      //extension_scope,
       JSExtensionsObjectName(options, field->file(), field->containing_type()),
       "index", StrCat(field->number()), "class", extension_scope, "name",
       extension_object_name, "binaryReaderFn",
@@ -3759,11 +3760,11 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   printer->Print(
       "// This registers the extension field with the extended class, so that\n"
       "// toObject() will function correctly.\n"
-      "if(!MethodOptions.extensions) {\n"
-      "    MethodOptions.extensions = [];\n"
-      "}\n"
-      //"$extendName$[$index$] = $class$.$name$;\n"
-      "MethodOptions.extensions[$index$] = foo;\n" //$class$.$name$;\n"
+      // "if(!MethodOptions.extensions) {\n"
+      // "    MethodOptions.extensions = [];\n"
+      // "}\n"
+      "$extendName$[$index$] = $class$.$name$;\n"
+      //"MethodOptions.extensions[$index$] = $class$.$name$;\n"
       "\n",
       "extendName",
       JSExtensionsObjectName(options, field->file(), field->containing_type()),

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3679,6 +3679,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // how to generate NEW class, not in options?
   // GenerateClassEs6(options, type_names, printer, desc);
   
+  const prefix = GetMessagePathPrefix(options, desc);
+  printer->Print(prefix);
   printer->Print(
       "\n"
       "/**\n"
@@ -3686,9 +3688,10 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * field named `$nameInComment$`.\n"
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
+      ""
       //"ExtendedClass.$name$ = new jspb.ExtensionFieldInfo(\n",
       "$classname$ = new jspb.ExtensionFieldInfo(\n",
-      "nameInComment", extension_object_name, "classname", desc->name(), //"name", extension_object_name,
+      "nameInComment", extension_object_name, "name", extension_object_name,
       "class", extension_scope, "extensionType", 
       JSFieldTypeAnnotation(options, field,
                             /* is_setter_argument = */ false,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3684,7 +3684,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // const std::string prefix = GetMessagePathPrefix(options, desc);
   // printer->Print(prefix);
   const std::string expr = type_names.JsExpression(desc->full_name());
-  printer->Print("\n\n" + alias + "\n\n");
+  printer->Print("\n\n" + expr + "\n\n");
   printer->Print(
       "\n"
       "/**\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3720,7 +3720,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       "\n"
       "MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       //"$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
-      "    $class$.$name$,\n"
+      "    foo,\n"//"    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"
       "    $binaryMessageSerializeFn$,\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3674,17 +3674,13 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
-  const Descriptor* desc = field->file()->message_type(0);
+  //This may not even be what I want for extension
+  const Descriptor* desc = field->file()->containing_type(); //containing_type()
   // how to generate NEW class, not in options?
   // GenerateClassEs6(options, type_names, printer, desc);
-  printer->Print("\n\n\n\n");
-  GenerateClassRegistration(options, type_names, printer, desc);
-  printer->Print("\n\n\n\n");
   
   printer->Print(
       "\n"
-      "class ExtendedClass extends $class$ {}\n //$nameInComment$"
-      //"class ExtendedMethodOptions extends proto.google.protobuf.MethodOptions {}\n"
       "/**\n"
       " * A tuple of {field number, class constructor} for the extension\n"
       " * field named `$nameInComment$`.\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3709,7 +3709,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   printer->Print(
       "\n"
-      "ExtendedMethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      //"ExtendedMethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      "$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3676,6 +3676,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   //This may not even be what I want for extension
   const Descriptor* desc = field->file()->message_type(0);
+  const std::string alias = type_names->Es6TypeName();
+  printer->Print("\n\n", alias, "\n\n");
   // how to generate NEW class, not in options?
   // GenerateClassEs6(options, type_names, printer, desc);
   

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = TypeNames::JsName(field->full_name());
+  std::string extension_scope = TypeNames::JsName(field->extension_scope()->name());
   //std::string extension_scope = type_names.JsExpression(field->extension_scope()->full_name());
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3736,7 +3736,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   printer->Print(
       "// This registers the extension field with the extended class, so that\n"
       "// toObject() will function correctly.\n"
-      "$extendName$[$index$] = $class$.$name$;\n"
+      //"$extendName$[$index$] = $class$.$name$;\n"
+      "ExtendedMethodOptions.extensions[$index$] = $class$.$name$;\n"
       "\n",
       "extendName",
       JSExtensionsObjectName(options, field->file(), field->containing_type()),

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3682,7 +3682,6 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // GenerateClassEs6(options, type_names, printer, desc);
 
   printer->Print(
-      "// $expr$\n"
       "\n"
       "/**\n"
       " * A tuple of {field number, class constructor} for the extension\n"
@@ -3693,7 +3692,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       //"$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
       "var foo = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
-      "class", extension_scope, "expr", expr, "extensionType", 
+      "class", extension_scope, "extensionType", 
       JSFieldTypeAnnotation(options, field,
                             /* is_setter_argument = */ false,
                             /* force_present = */ true,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3667,7 +3667,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   const TypeNames& type_names,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
-  std::string extension_scope = TypeNames::Es6TypeNames(options, field->file());//GetNamespace(options, field->file());
+  std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
+      
+      //ImportAliases(type_names, *file->dependency(i))
       // (field->extension_scope()
       //      ? field->extension_scope()->name()
       //      //? GetMessagePath(options, field->extension_scope())

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3675,7 +3675,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
   //This may not even be what I want for extension
-  const Descriptor* desc = field->file()->message_type(0);
+  // const Descriptor* desc = field->file()->message_type(0);
   // const std::string alias = TypeNames::Es6TypeName();
   // printer->Print("\n\n", alias, "\n\n");
   // how to generate NEW class, not in options?
@@ -3689,8 +3689,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
       ""
-      //"$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
-      "var foo = new jspb.ExtensionFieldInfo(\n",
+      "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
+      //"var foo = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
       "class", extension_scope, "extensionType", 
       JSFieldTypeAnnotation(options, field,
@@ -3718,12 +3718,13 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   printer->Print(
       "\n"
-      "if(!MethodOptions.extensionBinary) {\n"
-      "    MethodOptions.extensionBinary = [];\n"
-      "}\n"
-      "MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
-      //"$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
-      "    foo,\n"//"    $class$.$name$,\n"
+      // "if(!MethodOptions.extensionBinary) {\n"
+      // "    MethodOptions.extensionBinary = [];\n"
+      // "}\n"
+      //"MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      "$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      //"    foo,\n"
+      "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"
       "    $binaryMessageSerializeFn$,\n"
@@ -3748,11 +3749,11 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   printer->Print(
       "// This registers the extension field with the extended class, so that\n"
       "// toObject() will function correctly.\n"
-      "if(!MethodOptions.extensions) {\n"
-      "    MethodOptions.extensions = [];\n"
-      "}\n"
-      //"$extendName$[$index$] = $class$.$name$;\n"
-      "MethodOptions.extensions[$index$] = foo;\n" //$class$.$name$;\n"
+      // "if(!MethodOptions.extensions) {\n"
+      // "    MethodOptions.extensions = [];\n"
+      // "}\n"
+      "$extendName$[$index$] = $class$.$name$;\n"
+      //"MethodOptions.extensions[$index$] = foo;\n" //$class$.$name$;\n"
       "\n",
       "extendName",
       JSExtensionsObjectName(options, field->file(), field->containing_type()),

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = TypeNames::JsName(field->name());
+  std::string extension_scope = TypeNames::JsName(field->json_name());
   // if (field->is_extension()) {
   //   extension_scope = "foobarbaz\n";
   // }

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3674,7 +3674,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
-  const std::string classSymbol = options.WantEs6() ? desc->name() : GetMessagePath(options, desc);
+  const std::string classSymbol = options.WantEs6() ? desc->name() : GetMessagePath(options, field->extension_scope());
   //This may not even be what I want for extension
   // const Descriptor* desc = field->file()->message_type(0);
   // const std::string alias = TypeNames::Es6TypeName();

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3672,9 +3672,12 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
            : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
-  GenerateClass(options, type_names, printer, nullptr);
-  GenerateClassRegistration(options, type_names, printer, nullptr);
-  GenerateClassFields(options, type_names, printer, nullptr);
+
+  const Descriptor* desc = field->file()->message_type(0);
+
+  GenerateClass(options, type_names, printer, desc);
+  GenerateClassRegistration(options, type_names, printer, desc);
+  GenerateClassFields(options, type_names, printer, desc);
   printer->Print(
       "\n"
       //"class ExtendedClass extends $class$ {}\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   std::string extension_scope =
-      (field->extension_scope()
+      (!field->extension_scope()
            ? field->extension_scope()->name()
            //? GetMessagePath(options, field->extension_scope())
            : GetNamespace(options, field->file()));

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = TypeNames::JsName(field->json_name());
+  std::string extension_scope = TypeNames::JsName(field->type_name());
   // if (field->is_extension()) {
   //   extension_scope = "foobarbaz\n";
   // }

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3672,9 +3672,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
            : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
-  GenerateClass(options, type_names, printer, field->file());
-  GenerateClassRegistration(options, type_names, printer, field->file());
-  GenerateClassFields(options, type_names, printer, field->file());
+  GenerateClass(options, type_names, printer, field->containing_type());
+  GenerateClassRegistration(options, type_names, printer, field->containing_type());
+  GenerateClassFields(options, type_names, printer, field->containing_type());
   printer->Print(
       "\n"
       //"class ExtendedClass extends $class$ {}\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3675,7 +3675,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
   //This may not even be what I want for extension
-  const Descriptor* desc = field->file()->containing_type(); //containing_type()
+  const Descriptor* desc = field->file()->containing_type(0); //containing_type()
   // how to generate NEW class, not in options?
   // GenerateClassEs6(options, type_names, printer, desc);
   

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3676,12 +3676,12 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  
       //ImportAliases(type_names, *file->dependency(i))
-  std::string extension_scope = TypeNames::JsName(field->containing_type()->name());
-    //(field->extension_scope()
-    //  ? TypeNames::JsName(field->containing_type()->name()) //field->extension_scope()->name()
-      //      //? GetMessagePath(options, field->extension_scope())
-    //  : GetNamespace(options, field->file()));
+  std::string extension_scope_name =
+    (field->containing_type()
+      ? TypeNames::JsName(field->containing_type()->name())
+      : GetNamespace(options, field->file()));
 
+  const std::string extend_name = extension_scope_name + ".extensions";
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
   //const std::string classSymbol = options.WantEs6() ? field->extension_scope()->name() : GetMessagePath(options, field->extension_scope());
@@ -3732,15 +3732,14 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       // "if(!MethodOptions.extensionBinary) {\n"
       // "    MethodOptions.extensionBinary = [];\n"
       // "}\n"
-      //"MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
-      "$extendName$.extensionsBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      "$extendName$.Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"
       "    $binaryMessageSerializeFn$,\n"
       "    $binaryMessageDeserializeFn$,\n",
       "extendName",
-      extension_scope,
+      extension_scope + ".extensions",
       //JSExtensionsObjectName(options, field->file(), field->containing_type()),
       "index", StrCat(field->number()), "class", extension_scope, "name",
       extension_object_name, "binaryReaderFn",

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3679,7 +3679,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // how to generate NEW class, not in options?
   // GenerateClassEs6(options, type_names, printer, desc);
   
-  const prefix = GetMessagePathPrefix(options, desc);
+  const std::string prefix = GetMessagePathPrefix(options, desc);
   printer->Print(prefix);
   printer->Print(
       "\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = TypeNames::JsName(field->extension_scope()->full_name());
+  std::string extension_scope = TypeNames::JsName(field->full_name());
   //std::string extension_scope = type_names.JsExpression(field->extension_scope()->full_name());
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3686,8 +3686,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // const std::string expr = JsExpression(desc->full_name());
   // printer->Print("\n\n$expr$\n\n", expr);
   const std::string expr = GetMessagePath(options, desc);
-  printer->Print(expr);
+  //printer->Print(expr);
   printer->Print(
+      "// $expr$\n"
       "\n"
       "/**\n"
       " * A tuple of {field number, class constructor} for the extension\n"
@@ -3698,7 +3699,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
       //"var foo = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
-      "class", extension_scope, "extensionType", 
+      "class", extension_scope, "expr", expr, "extensionType", 
       JSFieldTypeAnnotation(options, field,
                             /* is_setter_argument = */ false,
                             /* force_present = */ true,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,9 +3668,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  //std::string extension_scope = TypeNames::JsName(field->full_name());
+  std::string extension_scope = type_names.SubmessageTypeRef(field);
   //std::string extension_scope = type_names.JsExpression(field->message_type());
-  std::string extension_scope = type_names.JsExpression(field->full_name());  
+  //std::string extension_scope = type_names.JsExpression(field->full_name());  
       //ImportAliases(type_names, *file->dependency(i))
       // (field->extension_scope()
       //      ? field->extension_scope()->name()

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -2071,7 +2071,7 @@ void Generator::GenerateClassEs6(const GeneratorOptions& options,
 
   printer->Indent();
 
-  GenerateClassConstructor(options, printer, desc);
+  GenerateClassConstructorAndDeclareExtensionFieldInfo(options, printer, desc);
 
   GenerateClassFieldInfo(options, printer, desc);
 
@@ -4361,11 +4361,11 @@ bool Generator::GenerateAll(const std::vector<const FileDescriptor*>& files,
                 options, &printer, one_desc);
           }
         }
-        for (auto one_desc : scc->descriptors) {
-          if (one_desc->containing_type() == nullptr) {
-            GenerateClass(options, type_names, &printer, one_desc);
-          }
-        }
+        // for (auto one_desc : scc->descriptors) {
+        //   if (one_desc->containing_type() == nullptr) {
+        //     GenerateClass(options, type_names, &printer, one_desc);
+        //   }
+        // }
 
         for (auto one_desc : scc->descriptors) {
           have_printed.insert(one_desc);

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = TypeNames::JsName(field->full_name());    
+  //std::string extension_scope = TypeNames::JsName(field->full_name());
+  std::string extension_scope = type_names.JsExpression(field->message_type(0));  
       //ImportAliases(type_names, *file->dependency(i))
       // (field->extension_scope()
       //      ? field->extension_scope()->name()

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3675,7 +3675,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   const Descriptor* desc = field->file()->message_type(0);
   // GenerateClass(options, type_names, printer, desc);
-  GenerateClassRegistration(options, type_names, printer, desc);
+  //GenerateClassRegistration(options, type_names, printer, desc);
   GenerateClassFields(options, type_names, printer, desc);
   printer->Print(
       "\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3672,9 +3672,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
            : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
-  GenerateClass(options, type_names, printer, field->message_type());
-  GenerateClassRegistration(options, type_names, printer, field->message_type());
-  GenerateClassFields(options, type_names, printer, field->message_type());
+  GenerateClass(options, type_names, printer, field->file());
+  GenerateClassRegistration(options, type_names, printer, field->file());
+  GenerateClassFields(options, type_names, printer, field->file());
   printer->Print(
       "\n"
       //"class ExtendedClass extends $class$ {}\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3687,6 +3687,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // printer->Print("\n\n$expr$\n\n", expr);
   const std::string expr = GetPrefix(options, field->file(), desc->containing_type());
   //printer->Print(expr);
+  printer->Print("goog.require('$name$');\n", "name", extension_object_name);
   printer->Print(
       "// $expr$\n"
       "\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -4349,11 +4349,11 @@ bool Generator::GenerateAll(const std::vector<const FileDescriptor*>& files,
                 options, &printer, one_desc);
           }
         }
-        // for (auto one_desc : scc->descriptors) {
-        //   if (one_desc->containing_type() == nullptr) {
-        //     GenerateClass(options, type_names, &printer, one_desc);
-        //   }
-        // }
+        for (auto one_desc : scc->descriptors) {
+          if (one_desc->containing_type() == nullptr) {
+            GenerateClass(options, type_names, &printer, one_desc);
+          }
+        }
 
         for (auto one_desc : scc->descriptors) {
           have_printed.insert(one_desc);

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = type_names.JsExpression(field->extension_scope());
+  std::string extension_scope = type_names.JsExpression(field->extension_scope()->full_name());
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  
       //ImportAliases(type_names, *file->dependency(i))

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3672,9 +3672,12 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
            : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
+  GenerateClass(options, type_names, printer, field);
+  GenerateClassRegistration(options, type_names, printer, field);
+  GenerateClassFields(options, type_names, printer, field);
   printer->Print(
       "\n"
-      "class ExtendedClass extends $class$ {}\n"
+      //"class ExtendedClass extends $class$ {}\n"
       "class ExtendedMethodOptions extends proto.google.protobuf.MethodOptions {}\n"
       "/**\n"
       " * A tuple of {field number, class constructor} for the extension\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3680,14 +3680,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // printer->Print("\n\n", alias, "\n\n");
   // how to generate NEW class, not in options?
   // GenerateClassEs6(options, type_names, printer, desc);
-  
-  // const std::string prefix = GetMessagePathPrefix(options, desc);
-  // printer->Print(prefix);
-  // const std::string expr = JsExpression(desc->full_name());
-  // printer->Print("\n\n$expr$\n\n", expr);
-  const std::string expr = GetPrefix(options, field->file(), desc->containing_type());
-  //printer->Print(expr);
-  printer->Print("goog.require('$name$');\n", "name", extension_object_name);
+
   printer->Print(
       "// $expr$\n"
       "\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3683,7 +3683,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   
   // const std::string prefix = GetMessagePathPrefix(options, desc);
   // printer->Print(prefix);
-  const std::string expr = type_names.JsExpression(desc->full_name()) 
+  const std::string expr = type_names.JsExpression(desc->full_name());
   printer->Print("\n\n" + alias + "\n\n");
   printer->Print(
       "\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = TypeNames::JsName(field->containing_type()->name());
+  std::string extension_scope = TypeNames::JsName(field->containing_type()->full_name());
   // if (field->is_extension()) {
   //   extension_scope = "foobarbaz\n";
   // }

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3709,9 +3709,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   printer->Print(
       "\n"
-      "if(!$extendName$Binary) {\n"
-      "    $extendName$Binary = [];\n"
-      "}\n"
+      // "if(!$extendName$Binary) {\n"
+      // "    $extendName$Binary = [];\n"
+      // "}\n"
       "$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
@@ -3737,9 +3737,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   printer->Print(
       "// This registers the extension field with the extended class, so that\n"
       "// toObject() will function correctly.\n"
-      "if(!$extendName$) {\n"
-      "    $extendName$ = [];\n"
-      "}\n"
+      // "if(!$extendName$) {\n"
+      // "    $extendName$ = [];\n"
+      // "}\n"
       "$extendName$[$index$] = $class$.$name$;\n"
       "\n",
       "extendName", extend_name, "index", StrCat(field->number()),

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = type_names.JsExpression(field);
+  std::string extension_scope = type_names.JsExpression(field->extension_scope());
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  
       //ImportAliases(type_names, *file->dependency(i))

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3674,7 +3674,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
-  const std::string classSymbol = options.WantEs6() ? desc->name() : GetMessagePath(options, field->extension_scope());
+  const std::string classSymbol = options.WantEs6() ? field->extension_scope()->name() : GetMessagePath(options, field->extension_scope());
   //This may not even be what I want for extension
   // const Descriptor* desc = field->file()->message_type(0);
   // const std::string alias = TypeNames::Es6TypeName();

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3740,8 +3740,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       "    $binaryMessageSerializeFn$,\n"
       "    $binaryMessageDeserializeFn$,\n",
       "extendName",
-      //extension_scope,
-      JSExtensionsObjectName(options, field->file(), field->containing_type()),
+      extension_scope,
+      //JSExtensionsObjectName(options, field->file(), field->containing_type()),
       "index", StrCat(field->number()), "class", extension_scope, "name",
       extension_object_name, "binaryReaderFn",
       JSBinaryReaderMethodName(options, field), "binaryWriterFn",
@@ -3767,7 +3767,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       //"MethodOptions.extensions[$index$] = $class$.$name$;\n"
       "\n",
       "extendName",
-      JSExtensionsObjectName(options, field->file(), field->containing_type()),
+      extension_scope,
+      //JSExtensionsObjectName(options, field->file(), field->containing_type()),
       "index", StrCat(field->number()), "class", extension_scope, "name",
       extension_object_name);
 }

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = type_names.JsExpression(field->extension_scope()->full_name());
+  std::string extension_scope = TypeNames::JsName(field->extension_scope()->full_name());
+  //std::string extension_scope = type_names.JsExpression(field->extension_scope()->full_name());
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  
       //ImportAliases(type_names, *file->dependency(i))

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3689,8 +3689,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
       ""
-      //"ExtendedClass.$name$ = new jspb.ExtensionFieldInfo(\n",
-      "$classname$ = new jspb.ExtensionFieldInfo(\n",
+      "ExtendedClass.$name$ = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
       "class", extension_scope, "extensionType", 
       JSFieldTypeAnnotation(options, field,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3669,7 +3669,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   const FieldDescriptor* field) const {
   std::string extension_scope =
       (field->extension_scope()
-           ? GetMessagePath(options, field->extension_scope())
+           ? field->extension_scope()->name() //GetMessagePath(options, field->extension_scope())
            : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
@@ -3693,7 +3693,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
       //"var foo = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
-      "class", classSymbol, "extensionType", 
+      "class", extension_scope, "extensionType", 
       JSFieldTypeAnnotation(options, field,
                             /* is_setter_argument = */ false,
                             /* force_present = */ true,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3686,7 +3686,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // const std::string expr = JsExpression(desc->full_name());
   // printer->Print("\n\n$expr$\n\n", expr);
   const std::string expr = GetMessagePath(options, desc);
-  printer->Print("\n\n$expr$\n\n", expr);
+  printer->Print(expr);
   printer->Print(
       "\n"
       "/**\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3679,7 +3679,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * field named `$nameInComment$`.\n"
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
-      "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
+      "foo.$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
       "class", extension_scope, "extensionType",
       JSFieldTypeAnnotation(options, field,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3679,8 +3679,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // how to generate NEW class, not in options?
   // GenerateClassEs6(options, type_names, printer, desc);
   
-  const std::string prefix = GetMessagePathPrefix(options, desc);
-  printer->Print(prefix);
+  // const std::string prefix = GetMessagePathPrefix(options, desc);
+  // printer->Print(prefix);
   printer->Print(
       "\n"
       "/**\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -2030,6 +2030,7 @@ void Generator::GenerateClass(const GeneratorOptions& options,
 
     if (options.import_style != GeneratorOptions::kImportClosure) {
       for (int i = 0; i < desc->extension_count(); i++) {
+        printer->Print("//about to generate extension\n");
         GenerateExtension(options, type_names, printer, desc->extension(i));
       }
     }
@@ -3674,10 +3675,10 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
   const Descriptor* desc = field->file()->message_type(0);
-  // GenerateClass(options, type_names, printer, desc);
+  // how to generate NEW class, not in options?
+  // GenerateClassEs6(options, type_names, printer, desc);
   printer->Print("\n\n\n\n");
   GenerateClassRegistration(options, type_names, printer, desc);
-  GenerateClassFields(options, type_names, printer, desc);
   printer->Print("\n\n\n\n");
   
   printer->Print(
@@ -3690,7 +3691,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
       //"ExtendedClass.$name$ = new jspb.ExtensionFieldInfo(\n",
-      "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
+      "$classname$ = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
       "class", extension_scope, "extensionType",
       JSFieldTypeAnnotation(options, field,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3675,7 +3675,6 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * field named `$name$`.\n"
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
-      ""
       "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
       "class", extension_scope_name, "name", extension_object_field_name, "extensionType", 
       JSFieldTypeAnnotation(options, field,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3677,8 +3677,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // GenerateClass(options, type_names, printer, desc);
   printer->Print("\n\n\n\n");
   GenerateClassRegistration(options, type_names, printer, desc);
+  GenerateClassFields(options, type_names, printer, desc);
   printer->Print("\n\n\n\n");
-  //GenerateClassFields(options, type_names, printer, desc);
+  
   printer->Print(
       "\n"
       //"class ExtendedClass extends $class$ {}\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3669,7 +3669,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
   std::string extension_scope = TypeNames::JsName(field->file()->extension(0)->full_name());
-  if (field->file()->is_extension()) {
+  if (field->is_extension()) {
     extension_scope = "foobarbaz\n";
   }
   //std::string extension_scope = type_names.JsExpression(field->extension_scope()->full_name());

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3683,7 +3683,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   
   // const std::string prefix = GetMessagePathPrefix(options, desc);
   // printer->Print(prefix);
-  const std::string expr = type_names->JsExpression(desc->full_name());
+  const std::string expr = JsExpression(desc->full_name());
   printer->Print("\n\n$expr$\n\n", expr);
   printer->Print(
       "\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3673,10 +3673,10 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
-  // const Descriptor* desc = field->file()->message_type(0);
+  const Descriptor* desc = field->file()->message_type(0);
   // GenerateClass(options, type_names, printer, desc);
-  // GenerateClassRegistration(options, type_names, printer, desc);
-  // GenerateClassFields(options, type_names, printer, desc);
+  GenerateClassRegistration(options, type_names, printer, desc);
+  GenerateClassFields(options, type_names, printer, desc);
   printer->Print(
       "\n"
       //"class ExtendedClass extends $class$ {}\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,10 +3668,10 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = TypeNames::JsName(field->file()->extension(0)->full_name());
-  if (field->is_extension()) {
-    extension_scope = "foobarbaz\n";
-  }
+  std::string extension_scope = TypeNames::JsName(field->name());
+  // if (field->is_extension()) {
+  //   extension_scope = "foobarbaz\n";
+  // }
   //std::string extension_scope = type_names.JsExpression(field->extension_scope()->full_name());
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3675,7 +3675,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   printer->Print(
       "\n"
       "class ExtendedClass extends $class$ {}\n"
-      "class ExtendedMethodOptions extends $extendName$ {}\n"
+      "class ExtendedMethodOptions extends proto.google.protobuf.MethodOptions {}\n"
       "/**\n"
       " * A tuple of {field number, class constructor} for the extension\n"
       " * field named `$nameInComment$`.\n"
@@ -3709,8 +3709,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   printer->Print(
       "\n"
-      //"ExtendedMethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
-      "$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      "ExtendedMethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      //"$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = TypeNames::JsName(field->extension(0)->full_name());
+  std::string extension_scope = TypeNames::JsName(field->file()->extension(0)->full_name());
   //std::string extension_scope = type_names.JsExpression(field->extension_scope()->full_name());
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3676,13 +3676,15 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   //This may not even be what I want for extension
   const Descriptor* desc = field->file()->message_type(0);
-  const std::string alias = TypeNames::Es6TypeName();
-  printer->Print("\n\n", alias, "\n\n");
+  // const std::string alias = TypeNames::Es6TypeName();
+  // printer->Print("\n\n", alias, "\n\n");
   // how to generate NEW class, not in options?
   // GenerateClassEs6(options, type_names, printer, desc);
   
   // const std::string prefix = GetMessagePathPrefix(options, desc);
   // printer->Print(prefix);
+  const expr = std::string TypeNames::JsExpression(desc) 
+  printer->Print("\n\n" + alias + "\n\n");
   printer->Print(
       "\n"
       "/**\n"
@@ -3746,8 +3748,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   printer->Print(
       "// This registers the extension field with the extended class, so that\n"
       "// toObject() will function correctly.\n"
-      //"$extendName$[$index$] = $class$.$name$;\n"
-      "ExtendedMethodOptions.extensions[$index$] = $class$.$name$;\n"
+      "$extendName$[$index$] = $class$.$name$;\n"
+      //"ExtendedMethodOptions.extensions[$index$] = $class$.$name$;\n"
       "\n",
       "extendName",
       JSExtensionsObjectName(options, field->file(), field->containing_type()),

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3669,7 +3669,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
   //std::string extension_scope = TypeNames::JsName(field->full_name());
-  std::string extension_scope = type_names.JsExpression(field->message_type());  
+  //std::string extension_scope = type_names.JsExpression(field->message_type());
+  std::string extension_scope = TypeNames::JsExpression(field-full_name());  
       //ImportAliases(type_names, *file->dependency(i))
       // (field->extension_scope()
       //      ? field->extension_scope()->name()

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3674,12 +3674,14 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   const std::string extension_object_name = JSObjectFieldName(options, field);
   printer->Print(
       "\n"
+      "class ExtendedClass extends $class$ {}\n"
+      "class ExtendedMethodOptions extends $extendName$ {}\n"
       "/**\n"
       " * A tuple of {field number, class constructor} for the extension\n"
       " * field named `$nameInComment$`.\n"
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
-      "foo.$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
+      "ExtendedClass.$name$ = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
       "class", extension_scope, "extensionType",
       JSFieldTypeAnnotation(options, field,
@@ -3707,7 +3709,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   printer->Print(
       "\n"
-      "$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      "ExtendedMethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3676,11 +3676,11 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  
       //ImportAliases(type_names, *file->dependency(i))
-  std::string extension_scope = \
-    (field->extension_scope()
-      ? TypeNames::JsName(field->containing_type()->name()) //field->extension_scope()->name()
+  std::string extension_scope = TypeNames::JsName(field->containing_type()->name());
+    //(field->extension_scope()
+    //  ? TypeNames::JsName(field->containing_type()->name()) //field->extension_scope()->name()
       //      //? GetMessagePath(options, field->extension_scope())
-      : GetNamespace(options, field->file()));
+    //  : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
 

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3669,7 +3669,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   const FieldDescriptor* field) const {
   std::string extension_scope =
       (field->extension_scope()
-           ? field->extension_scope()->name() //GetMessagePath(options, field->extension_scope())
+           //? field->extension_scope()->name()
+           ? GetMessagePath(options, field->extension_scope())
            : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = TypeNames::JsName(field->type_name());
+  std::string extension_scope = TypeNames::JsName(field->containing_type()->name());
   // if (field->is_extension()) {
   //   extension_scope = "foobarbaz\n";
   // }

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3674,6 +3674,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
+  const std::string classSymbol = options.WantEs6() ? desc->name() : GetMessagePath(options, desc);
   //This may not even be what I want for extension
   // const Descriptor* desc = field->file()->message_type(0);
   // const std::string alias = TypeNames::Es6TypeName();
@@ -3689,10 +3690,10 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
       ""
-      //"$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
-      "var foo = new jspb.ExtensionFieldInfo(\n",
+      "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
+      //"var foo = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
-      "class", extension_scope, "extensionType", 
+      "class", classSymbol, "extensionType", 
       JSFieldTypeAnnotation(options, field,
                             /* is_setter_argument = */ false,
                             /* force_present = */ true,
@@ -3724,7 +3725,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       "MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       //"$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    foo,\n"
-      "    $class$.$name$,\n"
+      //"    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"
       "    $binaryMessageSerializeFn$,\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3667,11 +3667,11 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   const TypeNames& type_names,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
-  std::string extension_scope =
-      (!field->extension_scope()
-           ? field->extension_scope()->name()
-           //? GetMessagePath(options, field->extension_scope())
-           : GetNamespace(options, field->file()));
+  std::string extension_scope = GetNamespace(options, field->file());
+      // (field->extension_scope()
+      //      ? field->extension_scope()->name()
+      //      //? GetMessagePath(options, field->extension_scope())
+      //      : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
 

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3683,7 +3683,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   
   // const std::string prefix = GetMessagePathPrefix(options, desc);
   // printer->Print(prefix);
-  const std::string expr = TypeNames::JsExpression(desc) 
+  const std::string expr = TypeNames::JsExpression(desc->full_name()) 
   printer->Print("\n\n" + alias + "\n\n");
   printer->Print(
       "\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3697,8 +3697,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
       ""
-      "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
-      //"var foo = new jspb.ExtensionFieldInfo(\n",
+      //"$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
+      "var foo = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
       "class", extension_scope, "expr", expr, "extensionType", 
       JSFieldTypeAnnotation(options, field,
@@ -3726,8 +3726,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   printer->Print(
       "\n"
-      //"ExtendedMethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
-      "$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      "MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
+      //"$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"
@@ -3753,8 +3753,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   printer->Print(
       "// This registers the extension field with the extended class, so that\n"
       "// toObject() will function correctly.\n"
-      "$extendName$[$index$] = $class$.$name$;\n"
-      //"ExtendedMethodOptions.extensions[$index$] = $class$.$name$;\n"
+      //"$extendName$[$index$] = $class$.$name$;\n"
+      "ExtendedMethodOptions.extensions[$index$] = foo;\n" //$class$.$name$;\n"
       "\n",
       "extendName",
       JSExtensionsObjectName(options, field->file(), field->containing_type()),
@@ -4156,7 +4156,7 @@ void Generator::GenerateFile(const GeneratorOptions& options,
 
   // Generate "require" statements.
   if (options.import_style == GeneratorOptions::kImportEs6) {
-    printer->Print("import jspb, MethodOptions from \"google-protobuf\";\n");
+    printer->Print("import jspb from \"google-protobuf\";\n");
 
     for (int i = 0; i < file->dependency_count(); i++) {
       std::string aliases_comma_delimited =

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -2181,12 +2181,6 @@ void Generator::GenerateClassConstructorAndDeclareExtensionFieldInfo(
       GenerateClassExtensionFieldInfo(options, printer, desc);
     }
   }
-  for (int i = 0; i < desc->nested_type_count(); i++) {
-    if (!IgnoreMessage(desc->nested_type(i))) {
-      GenerateClassConstructorAndDeclareExtensionFieldInfo(
-          options, printer, desc->nested_type(i));
-    }
-  }
 }
 
 void Generator::GenerateClassFieldInfo(const GeneratorOptions& options,
@@ -3238,9 +3232,8 @@ void Generator::GenerateClassExtensionFieldInfo(const GeneratorOptions& options,
         " *\n"
         " * @type {!Object<number, jspb.ExtensionFieldInfo>}\n"
         " */\n"
-        "$class$.extensions = {};\n"
-        "\n",
-        "class", GetMessagePath(options, desc));
+        "static extensions = {};\n"
+        "\n");
 
     printer->Print(
         "\n"
@@ -3259,9 +3252,8 @@ void Generator::GenerateClassExtensionFieldInfo(const GeneratorOptions& options,
         " *\n"
         " * @type {!Object<number, jspb.ExtensionFieldBinaryInfo>}\n"
         " */\n"
-        "$class$.extensionsBinary = {};\n"
-        "\n",
-        "class", GetMessagePath(options, desc));
+        "static extensionsBinary = {};\n"
+        "\n");
   }
 }
 

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3689,7 +3689,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
       ""
-      "ExtendedClass.$name$ = new jspb.ExtensionFieldInfo(\n",
+      "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
       "class", extension_scope, "extensionType", 
       JSFieldTypeAnnotation(options, field,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3668,7 +3668,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   io::Printer* printer,
                                   const FieldDescriptor* field) const {
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
-  std::string extension_scope = TypeNames::JsName(field->extension_scope());
+  std::string extension_scope = TypeNames::JsName(field->extension(0)->full_name());
   //std::string extension_scope = type_names.JsExpression(field->extension_scope()->full_name());
   //std::string extension_scope = type_names.JsExpression(field->message_type());
   //std::string extension_scope = type_names.JsExpression(field->full_name());  

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3724,7 +3724,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       "MethodOptions.extensionBinary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       //"$extendName$Binary[$index$] = new jspb.ExtensionFieldBinaryInfo(\n"
       "    foo,\n"
-      //"    $class$.$name$,\n"
+      "    $class$.$name$,\n"
       "    $binaryReaderFn$,\n"
       "    $binaryWriterFn$,\n"
       "    $binaryMessageSerializeFn$,\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3695,7 +3695,6 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
       ""
-      GetMessagePath(options, to_message)
       //"$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
       "var foo = new jspb.ExtensionFieldInfo(\n"
       "nameInComment", extension_object_name, "name", extension_object_name,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3670,7 +3670,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
   //std::string extension_scope = TypeNames::JsName(field->full_name());
   //std::string extension_scope = type_names.JsExpression(field->message_type());
-  std::string extension_scope = TypeNames::JsExpression(field-full_name());  
+  std::string extension_scope = TypeNames::JsExpression(field->full_name());  
       //ImportAliases(type_names, *file->dependency(i))
       // (field->extension_scope()
       //      ? field->extension_scope()->name()

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3678,7 +3678,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // how to generate NEW class, not in options?
   // GenerateClassEs6(options, type_names, printer, desc);
   printer->Print("\n\n\n\n");
-  //GenerateClassRegistration(options, type_names, printer, desc);
+  GenerateClassRegistration(options, type_names, printer, desc);
   printer->Print("\n\n\n\n");
   
   printer->Print(
@@ -3693,7 +3693,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       //"ExtendedClass.$name$ = new jspb.ExtensionFieldInfo(\n",
       "$classname$ = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
-      "class", extension_scope, "extensionType",
+      "class", extension_scope, "extensionType", "classname", desc->name(),
       JSFieldTypeAnnotation(options, field,
                             /* is_setter_argument = */ false,
                             /* force_present = */ true,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3672,9 +3672,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
            : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
-  GenerateClass(options, type_names, printer, extension_scope);
-  GenerateClassRegistration(options, type_names, printer, extension_scope);
-  GenerateClassFields(options, type_names, printer, extension_scope);
+  GenerateClass(options, type_names, printer, nullptr);
+  GenerateClassRegistration(options, type_names, printer, nullptr);
+  GenerateClassFields(options, type_names, printer, nullptr);
   printer->Print(
       "\n"
       //"class ExtendedClass extends $class$ {}\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3669,8 +3669,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
                                   const FieldDescriptor* field) const {
   std::string extension_scope =
       (field->extension_scope()
-           //? field->extension_scope()->name()
-           ? GetMessagePath(options, field->extension_scope())
+           ? field->extension_scope()->name()
+           //? GetMessagePath(options, field->extension_scope())
            : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -4156,7 +4156,7 @@ void Generator::GenerateFile(const GeneratorOptions& options,
 
   // Generate "require" statements.
   if (options.import_style == GeneratorOptions::kImportEs6) {
-    printer->Print("import jspb from \"google-protobuf\";\n");
+    printer->Print("import jspb, MethodOptions from \"google-protobuf\";\n");
 
     for (int i = 0; i < file->dependency_count(); i++) {
       std::string aliases_comma_delimited =

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3673,10 +3673,10 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
-  const Descriptor* desc = field->file()->message_type();
-  GenerateClass(options, type_names, printer, desc);
-  GenerateClassRegistration(options, type_names, printer, desc);
-  GenerateClassFields(options, type_names, printer, desc);
+  // const Descriptor* desc = field->file()->message_type(0);
+  // GenerateClass(options, type_names, printer, desc);
+  // GenerateClassRegistration(options, type_names, printer, desc);
+  // GenerateClassFields(options, type_names, printer, desc);
   printer->Print(
       "\n"
       //"class ExtendedClass extends $class$ {}\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3695,8 +3695,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
       ""
-      //"$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
-      "var foo = new jspb.ExtensionFieldInfo(\n"
+      "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
+      //"var foo = new jspb.ExtensionFieldInfo(\n",
       "nameInComment", extension_object_name, "name", extension_object_name,
       "class", extension_scope, "extensionType", 
       JSFieldTypeAnnotation(options, field,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3675,7 +3675,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   const std::string extension_object_name = JSObjectFieldName(options, field);
 
   //This may not even be what I want for extension
-  const Descriptor* desc = field->file()->containing_type(0); //containing_type()
+  const Descriptor* desc = field->file()->message_type(0);
   // how to generate NEW class, not in options?
   // GenerateClassEs6(options, type_names, printer, desc);
   

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3685,6 +3685,8 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   // printer->Print(prefix);
   // const std::string expr = JsExpression(desc->full_name());
   // printer->Print("\n\n$expr$\n\n", expr);
+  const std::string expr = GetMessagePath(options, desc);
+  printer->Print("\n\n$expr$\n\n", expr);
   printer->Print(
       "\n"
       "/**\n"
@@ -3693,7 +3695,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
       " * @type {!jspb.ExtensionFieldInfo<$extensionType$>}\n"
       " */\n"
       ""
-      "$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
+      GetMessagePath(options, to_message)
+      //"$class$.$name$ = new jspb.ExtensionFieldInfo(\n",
+      "var foo = new jspb.ExtensionFieldInfo(\n"
       "nameInComment", extension_object_name, "name", extension_object_name,
       "class", extension_scope, "extensionType", 
       JSFieldTypeAnnotation(options, field,

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3672,9 +3672,9 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
            : GetNamespace(options, field->file()));
 
   const std::string extension_object_name = JSObjectFieldName(options, field);
-  GenerateClass(options, type_names, printer, field->containing_type());
-  GenerateClassRegistration(options, type_names, printer, field->containing_type());
-  GenerateClassFields(options, type_names, printer, field->containing_type());
+  GenerateClass(options, type_names, printer, extension_scope);
+  GenerateClassRegistration(options, type_names, printer, extension_scope);
+  GenerateClassFields(options, type_names, printer, extension_scope);
   printer->Print(
       "\n"
       //"class ExtendedClass extends $class$ {}\n"

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -3670,7 +3670,7 @@ void Generator::GenerateExtension(const GeneratorOptions& options,
   //std::string extension_scope = ImportAliases(TypeNames::Es6TypeNames(options, field->file()), field->file());//GetNamespace(options, field->file());
   //std::string extension_scope = TypeNames::JsName(field->full_name());
   //std::string extension_scope = type_names.JsExpression(field->message_type());
-  std::string extension_scope = TypeNames::JsExpression(field->full_name());  
+  std::string extension_scope = type_names.JsExpression(field->full_name());  
       //ImportAliases(type_names, *file->dependency(i))
       // (field->extension_scope()
       //      ? field->extension_scope()->name()


### PR DESCRIPTION
Enable interpretable compilation of protos which use the `extend` keyword into JS (most pressingly, the longrunning -> http -> annotations dependency chain).

Testing of this is being done in `rules_ts_proto` repo: [PR#9](https://github.com/gonzojive/rules_ts_proto/pull/9/files)