### PR TITLE
Bazel: bzlmod support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/protocolbuffers/protobuf/issues/14313
+common --noenable_bzlmod

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,4 @@
+module(name = "protobuf_javascript_gonzojive", version = "3.21.5")
+
+bazel_dep(name = "protobuf", version = "27.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_pkg", version = "0.7.0")

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# When Bzlmod is enabled, this file replaces the content of the original WORKSPACE and
+# makes sure no WORKSPACE prefix or suffix are added when Bzlmod is enabled.


### PR DESCRIPTION
Make `bazel build` bzlmod instead of WORKSPACE to build.